### PR TITLE
chore: update github actions packages

### DIFF
--- a/.github/workflows/deploy-blog-in-prod.yaml
+++ b/.github/workflows/deploy-blog-in-prod.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,13 +29,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           build-args: |

--- a/.github/workflows/deploy-blog-in-prod.yaml
+++ b/.github/workflows/deploy-blog-in-prod.yaml
@@ -1,9 +1,13 @@
-name: Build the blog image and deploy
+name: Build Prod Image
 
 on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy-blog-in-stage.yaml
+++ b/.github/workflows/deploy-blog-in-stage.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -26,14 +26,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           build-args: |

--- a/.github/workflows/deploy-blog-in-stage.yaml
+++ b/.github/workflows/deploy-blog-in-stage.yaml
@@ -1,8 +1,12 @@
-name: Build the blog image and deploy in the stage environment
+name: Build Staging Image
 
 on:
   pull_request:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io

--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
     "*.+(js|jsx|ts|tsx|json|css|md|mdx)": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Update the GitHub Actions package, as they are deprecated for the most recent versions of Node.js

<img width="1400" alt="actions-warn" src="https://github.com/osscameroon/blog/assets/16793854/b992110a-65bb-434c-9e78-33884c97d498">
