### PR TITLE
Added scale effect to tags

### DIFF
--- a/pages/tags.js
+++ b/pages/tags.js
@@ -26,7 +26,7 @@ export default function Tags({ tags }) {
           {Object.keys(tags).length === 0 && 'No tags found.'}
           {sortedTags.map((t) => {
             return (
-              <div key={t} className="mt-2 mb-2 mr-5">
+              <div key={t} className="mt-2 mb-2 mr-5 hover:scale-105">
                 <Tag text={t} />
                 <Link
                   href={`/tags/${kebabCase(t)}`}


### PR DESCRIPTION
In order to enhance the UX.  I propose to add a `hover:scale-105` to tags in the tags page.